### PR TITLE
Update .NET Core framework version for Azure CLI

### DIFF
--- a/code/ArchiveBlobs/ArchiveBlobs.csproj
+++ b/code/ArchiveBlobs/ArchiveBlobs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Azure CLI stopped supporting .NET Core 2.2 (let alone 2.1). I've updated to 3.1, but I'm still working through the module to see if any version-specific issues might be present after the update.